### PR TITLE
remove purrr dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,14 +10,13 @@ Description: Defines aesthetically pleasing colour palettes.
 License: CC0
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 Depends: 
   R (>= 3.6)
 Imports: 
   ggplot2,
   graphics,
-  grDevices, 
-  purrr
+  grDevices
 Suggests:
   covr,
   knitr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Move Python implementation to separate repository
 * Add `scale_*_pretty_div()` diverging scale functions
 * Changes examples to mtcars data
+* Removed `purrr` dependency
 
 ## PrettyCols 1.0.1 2023_01_27
 

--- a/R/view_all_palettes.R
+++ b/R/view_all_palettes.R
@@ -31,7 +31,7 @@ view_all_palettes <- function(type = "all",
       n_col <- min(4, floor(sqrt(n_all)))
       n_row <- ceiling(n_all / n_col)
       par(mfrow = c(n_row, n_col))
-      purrr::map(.x = names(to_print), .f = ~print(prettycols(.x)))
+      lapply(names(to_print), function(.x) print(prettycols(.x)))
       par(mfrow = c(1, 1))
     } else {
       if (colourblind_friendly == TRUE) {
@@ -47,7 +47,7 @@ view_all_palettes <- function(type = "all",
       n_col <- min(3, floor(sqrt(n_all)))
       n_row <- ceiling(n_all / n_col)
       par(mfrow = c(n_row, n_col))
-      purrr::map(.x = names(filtered_palettes), .f = ~print(prettycols(.x)))
+      lapply(names(filtered_palettes), function(.x) print(prettycols(.x)))
       par(mfrow = c(1, 1))
     }
   }


### PR DESCRIPTION
removed `purrr` package dependency. All test pass regarding this change when running `devtools::test()` and `devtools::check()`

However about 15 warnings occur regarding
The `scale_name` argument of `discrete_scale()` is deprecated as of ggplot2 3.5.0.
which can easily be fixed.